### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/FlippingBinaryLLC/singletonset-rs/compare/v0.1.0...v0.1.1) - 2024-11-30
+
+### Added
+
+- Add convenience methods
+- Add `Types` iterator and `Type` identifier
+- Implement `AsRef` and `AsMut`
+
+### Fixed
+
+- Update MSRV to align with stable version of `try_reserve()`
+
+### Other
+
+- Update example and readme
+- Use `hashbrown` directly
+- Use tuple instead of named fields

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "singletonset"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jon Musselwhite"]
 categories = ["data-structures"]
 description = "This crate provides the `SingletonSet` data structure, which makes it easy to store a single instance each of various types within a single set."


### PR DESCRIPTION
## 🤖 New release
* `singletonset`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/FlippingBinaryLLC/singletonset-rs/compare/v0.1.0...v0.1.1) - 2024-11-30

### Added

- Add convenience methods
- Add `Types` iterator and `Type` identifier
- Implement `AsRef` and `AsMut`

### Fixed

- Update MSRV to align with stable version of `try_reserve()`

### Other

- Update example and readme
- Use `hashbrown` directly
- Use tuple instead of named fields
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).