### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/FlippingBinaryLLC/singletonset-rs/compare/v0.1.1...v0.1.2) - 2024-12-04
+
+### Added
+
+- Some convenience functions for `Type`
+
+### Other
+
+- Added and updated links and phrasing
+- Switch to `indexmap` for internal storage
+
 ## [0.1.1](https://github.com/FlippingBinaryLLC/singletonset-rs/compare/v0.1.0...v0.1.1) - 2024-11-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "singletonset"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jon Musselwhite"]
 categories = ["data-structures"]
 description = "This crate provides the `SingletonSet` data structure, which makes it easy to store a single instance each of various types within a single set."


### PR DESCRIPTION
## 🤖 New release
* `singletonset`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/FlippingBinaryLLC/singletonset-rs/compare/v0.1.1...v0.1.2) - 2024-12-04

### Added

- Some convenience functions for `Type`

### Other

- Added and updated links and phrasing
- Switch to `indexmap` for internal storage
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).